### PR TITLE
Add support for ismartgate mini by making door2 and door3 optional

### DIFF
--- a/ismartgate/common.py
+++ b/ismartgate/common.py
@@ -557,7 +557,7 @@ def element_to_ismartgate_info_response(element: Element) -> ISmartGateInfoRespo
         newfirmware=element_text_or_raise(element, "newfirmware").lower() == "yes",
         door1=ismartgate_door_or_raise(1, element_or_raise(element, "door1")),
         door2=ismartgate_door_or_empty(2, element_or_raise(element, "door2")),
-        door3=ismartgate_door_or_raise(3, element_or_raise(element, "door3")),
+        door3=ismartgate_door_or_empty(3, element_or_raise(element, "door3")),
         network=network_or_raise(element_or_raise(element, "network")),
         wifi=wifi_or_raise(element_or_raise(element, "wifi")),
     )


### PR DESCRIPTION
The iSmartGate Mini only has support for one door, right now there are some fields for door2 and door3 which are required and cause an error. This PR makes door2 and door3 return an empty object in the event that a device support less doors is detected.

This was tested on my iSmartGate Mini.